### PR TITLE
BOLT-3025: Add indexes module in SDK

### DIFF
--- a/src/services/databases/README.md
+++ b/src/services/databases/README.md
@@ -518,13 +518,16 @@ const sortedByUsage = await client.indexes.listIndexes('users', {
 
 ```typescript
 // Delete a specific index
-const deleteResult = await client.indexes.deleteIndex('users_btree_email');
+const deleteResult = await client.indexes.deleteIndex(
+  'users',
+  'users_btree_email'
+);
 
 // Delete multiple indexes
 const indexNames = ['users_btree_email', 'users_hash_status', 'users_gin_tags'];
 
 for (const indexName of indexNames) {
-  const result = await client.indexes.deleteIndex(indexName);
+  const result = await client.indexes.deleteIndex('users', indexName);
   if (result.error) {
     console.error(`Failed to delete ${indexName}:`, result.error);
   } else {
@@ -539,7 +542,7 @@ async function cleanupUnusedIndexes(tableName: string) {
   });
 
   for (const index of indexes.items) {
-    await client.indexes.deleteIndex(index.indexrelname);
+    await client.indexes.deleteIndex(tableName, index.indexrelname);
     console.log(`Deleted unused index: ${index.indexrelname}`);
   }
 }
@@ -880,7 +883,7 @@ For the complete API reference including all methods, parameters, and return typ
 
 - **`client.indexes.addIndex(tableName, request)`**: Create a new index
 - **`client.indexes.listIndexes(tableName, query)`**: List indexes with filtering and pagination
-- **`client.indexes.deleteIndex(indexName)`**: Delete an index by name
+- **`client.indexes.deleteIndex(tableName, indexName)`**: Delete an index by name
 
 #### SQL Operations
 

--- a/src/services/databases/README.md
+++ b/src/services/databases/README.md
@@ -21,6 +21,7 @@ const client = createClient('your-api-key', {
 const tables = client.tables;
 const columns = client.columns;
 const records = client.records;
+const indexes = client.indexes;
 ```
 
 Run your file to create client:
@@ -442,6 +443,176 @@ const deleteWithFilters = await client.records.delete('users', {
 });
 ```
 
+## Index Operations
+
+### Creating Indexes
+
+Create database indexes to optimize query performance:
+
+```typescript
+// Create different types of indexes
+const indexTypes = [
+  {
+    field_names: ['email'],
+    method: 'btree', // Best for equality and range queries
+  },
+  {
+    field_names: ['status'],
+    method: 'hash', // Best for exact equality matches
+  },
+  {
+    field_names: ['tags'],
+    method: 'gin', // Best for array fields and complex data types
+  },
+  {
+    field_names: ['created_at'],
+    method: 'brin', // Best for large tables with ordered data
+  },
+  {
+    field_names: ['coordinates'],
+    method: 'spgist', // Best for geometric and specialized data types
+  },
+];
+
+for (const indexData of indexTypes) {
+  const result = await client.indexes.addIndex('users', indexData);
+  if (result.error) {
+    console.error(`Failed to create ${indexData.method} index:`, result.error);
+  } else {
+    console.log(`Created ${indexData.method} index:`, result.data.index_name);
+  }
+}
+
+// Composite index for complex queries
+const compositeIndex = await client.indexes.addIndex('events', {
+  field_names: ['user_id', 'event_type', 'created_at'],
+  method: 'btree',
+});
+```
+
+### Listing and Filtering Indexes
+
+```typescript
+// List all indexes for a table
+const allIndexes = await client.indexes.listIndexes('users', {
+  page: { page_no: 1, page_size: 50 },
+});
+
+// Filter indexes by method
+const btreeIndexes = await client.indexes.listIndexes('users', {
+  filters: [{ field: 'method', operator: '=', values: ['btree'] }],
+});
+
+// Find unused indexes (candidates for cleanup)
+const unusedIndexes = await client.indexes.listIndexes('users', {
+  filters: [{ field: 'idx_scan', operator: '=', values: [0] }],
+});
+
+// Sort by usage statistics
+const sortedByUsage = await client.indexes.listIndexes('users', {
+  sort: [{ field: 'idx_scan', direction: 'desc' }],
+});
+```
+
+### Deleting Indexes
+
+```typescript
+// Delete a specific index
+const deleteResult = await client.indexes.deleteIndex('users_btree_email');
+
+// Delete multiple indexes
+const indexNames = ['users_btree_email', 'users_hash_status', 'users_gin_tags'];
+
+for (const indexName of indexNames) {
+  const result = await client.indexes.deleteIndex(indexName);
+  if (result.error) {
+    console.error(`Failed to delete ${indexName}:`, result.error);
+  } else {
+    console.log(`Deleted ${indexName} successfully`);
+  }
+}
+
+// Clean up unused indexes
+async function cleanupUnusedIndexes(tableName: string) {
+  const { data: indexes } = await client.indexes.listIndexes(tableName, {
+    filters: [{ field: 'idx_scan', operator: '=', values: [0] }],
+  });
+
+  for (const index of indexes.items) {
+    await client.indexes.deleteIndex(index.indexrelname);
+    console.log(`Deleted unused index: ${index.indexrelname}`);
+  }
+}
+```
+
+### Index Performance Analysis
+
+```typescript
+// Analyze index usage and performance
+async function analyzeIndexPerformance(tableName: string) {
+  const { data: indexes } = await client.indexes.listIndexes(tableName, {
+    page: { page_no: 1, page_size: 1000 },
+  });
+
+  const analysis = {
+    total: indexes.items.length,
+    unused: 0,
+    lowEfficiency: 0,
+    heavilyUsed: 0,
+  };
+
+  indexes.items.forEach((index) => {
+    const scans = index.idx_scan || 0;
+    const tuplesRead = index.idx_tup_read || 0;
+    const tuplesFetched = index.idx_tup_fetch || 0;
+    const efficiency = tuplesRead > 0 ? (tuplesFetched / tuplesRead) * 100 : 0;
+
+    if (scans === 0) {
+      analysis.unused++;
+    } else if (efficiency < 30) {
+      analysis.lowEfficiency++;
+    } else if (scans > 1000) {
+      analysis.heavilyUsed++;
+    }
+
+    console.log(
+      `${index.indexrelname}: ${scans} scans, ${efficiency.toFixed(1)}% efficiency`
+    );
+  });
+
+  return analysis;
+}
+
+// Usage
+const performance = await analyzeIndexPerformance('users');
+console.log('Index Performance Analysis:', performance);
+```
+
+### Chained Access Pattern
+
+```typescript
+// Using chained access for index operations
+const { data: index } = await client
+  .from('users')
+  .indexes()
+  .addIndex({
+    field_names: ['email'],
+    method: 'btree',
+  });
+
+const { data: indexes } = await client
+  .from('users')
+  .indexes()
+  .listIndexes({
+    page: { page_no: 1, page_size: 50 },
+  });
+
+const { data: result } = await client
+  .from('users')
+  .indexes()
+  .deleteIndex('users_btree_email');
+```
+
 ## SQL Operations
 
 ### Text-to-SQL Conversion
@@ -704,6 +875,12 @@ For the complete API reference including all methods, parameters, and return typ
 - **`client.records.findAll(tableName, options?)`**: List records with optional filtering
 - **`client.records.update(tableName, options)`**: Update records by filters
 - **`client.records.delete(tableName, options)`**: Delete records by filters or IDs
+
+#### Indexes
+
+- **`client.indexes.addIndex(tableName, request)`**: Create a new index
+- **`client.indexes.listIndexes(tableName, query)`**: List indexes with filtering and pagination
+- **`client.indexes.deleteIndex(indexName)`**: Delete an index by name
 
 #### SQL Operations
 

--- a/src/services/databases/examples/basic/comprehensive-database-operations-demo.ts
+++ b/src/services/databases/examples/basic/comprehensive-database-operations-demo.ts
@@ -870,7 +870,10 @@ class ComprehensiveDatabaseOperationsDemo {
 
     for (const indexName of toDelete) {
       console.log(`📝 Delete (direct): ${indexName}`);
-      const delDirect = await this.client.indexes.deleteIndex(indexName);
+      const delDirect = await this.client.indexes.deleteIndex(
+        this.createdTableName,
+        indexName
+      );
       if (isErrorResponse(delDirect)) {
         console.error('❌ deleteIndex (direct) failed:', delDirect.error);
       } else {

--- a/src/services/databases/src/api/clients/indexes-api-client.ts
+++ b/src/services/databases/src/api/clients/indexes-api-client.ts
@@ -1,0 +1,193 @@
+import {
+  AddIndexRequest,
+  AddIndexResponse,
+  DeleteIndexRequest,
+  DeleteIndexResponse,
+  ListIndexesQuery,
+  ListIndexesResponse,
+} from '../../types/api/index';
+import type { Environment, Region } from '../../types/config/environment';
+import { REGION_CONFIGS } from '../../types/config/environment';
+import { createHttpAdapter } from '../../utils/http';
+import { HttpAdapter } from '../../utils/http/adapter';
+import { buildIndexEndpointPath, INDEX_ENDPOINTS } from '../endpoints/indexes';
+
+export interface IndexesApiClientConfig {
+  apiKey: string;
+  environment?: Environment;
+  region?: Region;
+  timeout?: number;
+  debug?: boolean;
+  retryAttempts?: number;
+  retryDelay?: number;
+  headers?: Record<string, string>;
+}
+
+interface BolticSuccessResponse<T = unknown> {
+  data: T;
+  message?: string;
+}
+
+// Note: No BolticListResponse needed in this client; API returns wrapped success lists
+
+interface BolticErrorResponse {
+  data?: never;
+  error: {
+    code?: string;
+    message?: string;
+    meta?: string[];
+  };
+}
+
+export class IndexesApiClient {
+  private httpAdapter: HttpAdapter;
+  private config: IndexesApiClientConfig;
+  private baseURL: string;
+
+  constructor(
+    apiKey: string,
+    config: Omit<IndexesApiClientConfig, 'apiKey'> = {}
+  ) {
+    this.config = { apiKey, ...config };
+    this.httpAdapter = createHttpAdapter();
+
+    const environment = config.environment || 'prod';
+    const region = config.region || 'asia-south1';
+    this.baseURL = this.getBaseURL(environment, region);
+  }
+
+  private getBaseURL(environment: Environment, region: Region): string {
+    const regionConfig = REGION_CONFIGS[region];
+    if (!regionConfig) {
+      throw new Error(`Unsupported region: ${region}`);
+    }
+
+    const envConfig = regionConfig[environment];
+    if (!envConfig) {
+      throw new Error(
+        `Unsupported environment: ${environment} for region: ${region}`
+      );
+    }
+
+    return `${envConfig.baseURL}/v1`;
+  }
+
+  async addIndex(
+    tableId: string,
+    request: AddIndexRequest
+  ): Promise<BolticSuccessResponse<AddIndexResponse> | BolticErrorResponse> {
+    try {
+      const endpoint = INDEX_ENDPOINTS.create;
+      const url = `${this.baseURL}${buildIndexEndpointPath(endpoint, { table_id: tableId })}`;
+      const response = await this.httpAdapter.request({
+        url,
+        method: endpoint.method,
+        headers: this.buildHeaders(),
+        data: request,
+        timeout: this.config.timeout,
+      });
+      return response.data as BolticSuccessResponse<AddIndexResponse>;
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+
+  async listIndexes(
+    tableId: string,
+    query: ListIndexesQuery
+  ): Promise<BolticSuccessResponse<ListIndexesResponse> | BolticErrorResponse> {
+    try {
+      const endpoint = INDEX_ENDPOINTS.list;
+      const url = `${this.baseURL}${buildIndexEndpointPath(endpoint, { table_id: tableId })}`;
+
+      const response = await this.httpAdapter.request({
+        url,
+        method: endpoint.method,
+        headers: this.buildHeaders(),
+        data: query,
+        timeout: this.config.timeout,
+      });
+
+      return response.data as BolticSuccessResponse<ListIndexesResponse>;
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+
+  async deleteIndex(
+    request: DeleteIndexRequest
+  ): Promise<BolticSuccessResponse<DeleteIndexResponse> | BolticErrorResponse> {
+    try {
+      const endpoint = INDEX_ENDPOINTS.delete;
+      const url = `${this.baseURL}${buildIndexEndpointPath(endpoint)}`;
+
+      const response = await this.httpAdapter.request({
+        url,
+        method: endpoint.method,
+        headers: this.buildHeaders(),
+        data: request,
+        timeout: this.config.timeout,
+      });
+
+      return response.data as BolticSuccessResponse<DeleteIndexResponse>;
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'x-boltic-token': this.config.apiKey,
+    };
+  }
+
+  private formatErrorResponse(error: unknown): BolticErrorResponse {
+    if (this.config.debug) {
+      console.error('Indexes API Error:', error);
+    }
+
+    // Handle different error types following Boltic format
+    if (error && typeof error === 'object' && 'response' in error) {
+      const apiError = error as {
+        response?: {
+          data?: BolticErrorResponse;
+          status?: number;
+        };
+      };
+
+      // If API already returned Boltic format, use it
+      if (apiError.response?.data?.error) {
+        return apiError.response.data;
+      }
+
+      // Otherwise format it to Boltic structure
+      return {
+        error: {
+          code: 'API_ERROR',
+          message: (error as unknown as Error).message || 'Unknown API error',
+          meta: [`Status: ${apiError.response?.status || 'unknown'}`],
+        },
+      };
+    }
+
+    if (error && typeof error === 'object' && 'message' in error) {
+      return {
+        error: {
+          code: 'CLIENT_ERROR',
+          message: (error as Error).message,
+          meta: ['Client-side error occurred'],
+        },
+      };
+    }
+
+    return {
+      error: {
+        code: 'UNKNOWN_ERROR',
+        message: 'An unexpected error occurred',
+        meta: ['Unknown error type'],
+      },
+    };
+  }
+}

--- a/src/services/databases/src/api/clients/indexes-api-client.ts
+++ b/src/services/databases/src/api/clients/indexes-api-client.ts
@@ -115,11 +115,12 @@ export class IndexesApiClient {
   }
 
   async deleteIndex(
+    tableId: string,
     request: DeleteIndexRequest
   ): Promise<BolticSuccessResponse<DeleteIndexResponse> | BolticErrorResponse> {
     try {
       const endpoint = INDEX_ENDPOINTS.delete;
-      const url = `${this.baseURL}${buildIndexEndpointPath(endpoint)}`;
+      const url = `${this.baseURL}${buildIndexEndpointPath(endpoint, { table_id: tableId })}`;
 
       const response = await this.httpAdapter.request({
         url,

--- a/src/services/databases/src/api/endpoints/indexes.ts
+++ b/src/services/databases/src/api/endpoints/indexes.ts
@@ -1,0 +1,51 @@
+export interface IndexApiEndpoint {
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  authenticated: boolean;
+  rateLimit?: {
+    requests: number;
+    window: number;
+  };
+}
+
+export interface IndexEndpoints {
+  create: IndexApiEndpoint;
+  list: IndexApiEndpoint;
+  delete: IndexApiEndpoint;
+}
+
+export const INDEX_ENDPOINTS: IndexEndpoints = {
+  create: {
+    path: '/tables/indexes/{table_id}',
+    method: 'POST',
+    authenticated: true,
+  },
+  list: {
+    path: '/tables/indexes/{table_id}/list',
+    method: 'POST',
+    authenticated: true,
+  },
+  delete: {
+    path: '/tables/indexes',
+    method: 'DELETE',
+    authenticated: true,
+  },
+};
+
+export const buildIndexEndpointPath = (
+  endpoint: IndexApiEndpoint,
+  params: Record<string, string> = {}
+): string => {
+  let path = endpoint.path;
+
+  Object.entries(params).forEach(([key, value]) => {
+    path = path.replace(`{${key}}`, encodeURIComponent(value));
+  });
+
+  const unreplacedParams = path.match(/\{([^}]+)\}/g);
+  if (unreplacedParams) {
+    throw new Error(`Missing path parameters: ${unreplacedParams.join(', ')}`);
+  }
+
+  return path;
+};

--- a/src/services/databases/src/api/endpoints/indexes.ts
+++ b/src/services/databases/src/api/endpoints/indexes.ts
@@ -26,7 +26,7 @@ export const INDEX_ENDPOINTS: IndexEndpoints = {
     authenticated: true,
   },
   delete: {
-    path: '/tables/indexes',
+    path: '/tables/indexes/{table_id}',
     method: 'DELETE',
     authenticated: true,
   },

--- a/src/services/databases/src/client/boltic-client.ts
+++ b/src/services/databases/src/client/boltic-client.ts
@@ -147,8 +147,8 @@ export class BolticClient {
         this.indexResource.addIndex(tableName, payload),
       listIndexes: (tableName: string, query: ListIndexesQuery) =>
         this.indexResource.listIndexes(tableName, query),
-      deleteIndex: (indexName: string) =>
-        this.indexResource.deleteIndex(indexName),
+      deleteIndex: (tableName: string, indexName: string) =>
+        this.indexResource.deleteIndex(tableName, indexName),
     };
   }
 
@@ -213,7 +213,7 @@ export class BolticClient {
         listIndexes: (query: ListIndexesQuery) =>
           this.indexResource.listIndexes(tableName, query),
         deleteIndex: (indexName: string) =>
-          this.indexResource.deleteIndex(indexName),
+          this.indexResource.deleteIndex(tableName, indexName),
       }),
     };
   }

--- a/src/services/databases/src/client/resources/indexes.ts
+++ b/src/services/databases/src/client/resources/indexes.ts
@@ -1,0 +1,98 @@
+import { IndexesApiClient } from '../../api/clients/indexes-api-client';
+import {
+  AddIndexRequest,
+  AddIndexResponse,
+  DeleteIndexRequest,
+  DeleteIndexResponse,
+  ListIndexesQuery,
+  ListIndexesResponse,
+} from '../../types/api/index';
+import { BaseClient } from '../core/base-client';
+import { TableResource } from './table';
+
+import {
+  BolticErrorResponse,
+  BolticSuccessResponse,
+} from '../../types/common/responses';
+
+export class IndexResource {
+  private apiClient: IndexesApiClient;
+  private tableResource: TableResource;
+  private client: BaseClient;
+
+  constructor(client: BaseClient) {
+    this.client = client;
+
+    const config = client.getConfig();
+    this.apiClient = new IndexesApiClient(config.apiKey, {
+      environment: config.environment,
+      region: config.region,
+      timeout: config.timeout,
+      debug: config.debug,
+      retryAttempts: config.retryAttempts,
+      retryDelay: config.retryDelay,
+      headers: config.headers,
+    });
+
+    this.tableResource = new TableResource(client);
+  }
+
+  private async resolveTableId(tableName: string): Promise<string> {
+    const tableResult = await this.tableResource.findByName(tableName);
+    if (!tableResult.data) throw new Error(`Table not found: ${tableName}`);
+    return tableResult.data.id;
+  }
+
+  async addIndex(
+    tableName: string,
+    request: AddIndexRequest
+  ): Promise<BolticSuccessResponse<AddIndexResponse> | BolticErrorResponse> {
+    try {
+      const tableId = await this.resolveTableId(tableName);
+      return await this.apiClient.addIndex(tableId, request);
+    } catch (error) {
+      return {
+        error: {
+          code: 'CLIENT_ERROR',
+          message: (error as Error)?.message || 'Failed to add index',
+          meta: ['IndexResource.addIndex'],
+        },
+      };
+    }
+  }
+
+  async listIndexes(
+    tableName: string,
+    query: ListIndexesQuery
+  ): Promise<BolticSuccessResponse<ListIndexesResponse> | BolticErrorResponse> {
+    try {
+      const tableId = await this.resolveTableId(tableName);
+      return await this.apiClient.listIndexes(tableId, query);
+    } catch (error) {
+      return {
+        error: {
+          code: 'CLIENT_ERROR',
+          message: (error as Error)?.message || 'Failed to list indexes',
+          meta: ['IndexResource.listIndexes'],
+        },
+      };
+    }
+  }
+
+  async deleteIndex(
+    indexName: string
+  ): Promise<BolticSuccessResponse<DeleteIndexResponse> | BolticErrorResponse> {
+    try {
+      const request: DeleteIndexRequest = { index_name: indexName };
+      return await this.apiClient.deleteIndex(request);
+    } catch (error) {
+      return {
+        error: {
+          code: 'CLIENT_ERROR',
+          message: (error as Error)?.message || 'Failed to delete index',
+          meta: ['IndexResource.deleteIndex'],
+        },
+      };
+    }
+  }
+}

--- a/src/services/databases/src/client/resources/indexes.ts
+++ b/src/services/databases/src/client/resources/indexes.ts
@@ -80,11 +80,13 @@ export class IndexResource {
   }
 
   async deleteIndex(
+    tableName: string,
     indexName: string
   ): Promise<BolticSuccessResponse<DeleteIndexResponse> | BolticErrorResponse> {
     try {
+      const tableId = await this.resolveTableId(tableName);
       const request: DeleteIndexRequest = { index_name: indexName };
-      return await this.apiClient.deleteIndex(request);
+      return await this.apiClient.deleteIndex(tableId, request);
     } catch (error) {
       return {
         error: {

--- a/src/services/databases/src/index.ts
+++ b/src/services/databases/src/index.ts
@@ -9,6 +9,14 @@ export type {
   ColumnUpdateRequest,
 } from './types/api/column';
 export type {
+  AddIndexRequest,
+  AddIndexResponse,
+  DeleteIndexRequest,
+  DeleteIndexResponse,
+  ListIndexesQuery,
+  ListIndexesResponse,
+} from './types/api/index';
+export type {
   RecordData,
   RecordDeleteOptions,
   RecordQueryOptions,
@@ -43,10 +51,10 @@ export { SchemaHelpers } from './utils/table/schema-helpers';
 
 // Filter utilities and constants
 export {
-  buildApiFilters,
-  createFilter,
   FILTER_OPERATORS,
   FilterBuilder,
+  buildApiFilters,
+  createFilter,
   mapFiltersToWhere,
   mapWhereToFilters,
   normalizeFilters,
@@ -61,11 +69,11 @@ export { createTableBuilder } from './client/resources/table-builder';
 // Error handling utilities
 export {
   ApiError,
+  ValidationError,
   createErrorWithContext,
   formatError,
   getHttpStatusCode,
   isNetworkError,
-  ValidationError,
 } from './errors/utils';
 export type { ValidationFailure } from './errors/utils';
 

--- a/src/services/databases/src/types/api/index.ts
+++ b/src/services/databases/src/types/api/index.ts
@@ -42,5 +42,5 @@ export interface DeleteIndexRequest {
 }
 
 export interface DeleteIndexResponse {
-  success: boolean;
+  message?: string;
 }

--- a/src/services/databases/src/types/api/index.ts
+++ b/src/services/databases/src/types/api/index.ts
@@ -1,0 +1,46 @@
+export interface AddIndexRequest {
+  field_names: string[];
+  method: 'btree' | 'hash' | 'spgist' | 'gin' | 'brin';
+}
+
+export interface AddIndexResponse {
+  index_name: string;
+  method: string;
+  fields: string[];
+  field_ids?: string[];
+  created_at?: string;
+  created_by?: string;
+}
+
+export interface ListIndexesQuery {
+  page?: { page_no: number; page_size: number };
+  filters?: Array<{ field: string; operator: string; values: unknown[] }>;
+  sort?: Array<{ field: string; direction: 'asc' | 'desc' }>;
+}
+
+export interface IndexListItem {
+  schemaname?: string;
+  relname?: string;
+  indexrelname: string;
+  method?: string;
+  idx_scan?: number;
+  idx_tup_read?: number;
+  idx_tup_fetch?: number;
+  field_ids?: string[];
+  fields?: string[];
+  created_at?: string;
+  created_by?: string;
+}
+
+export interface ListIndexesResponse {
+  items: IndexListItem[];
+  page?: { page_no: number; page_size: number; total?: number };
+}
+
+export interface DeleteIndexRequest {
+  index_name: string;
+}
+
+export interface DeleteIndexResponse {
+  success: boolean;
+}


### PR DESCRIPTION
## PR Description: Expose Indexes as Top-Level Module

### Summary
Refactored the indexes module to be exposed as a top-level `client.indexes` API instead of nested under `client.tables.indexes`, providing a more intuitive and consistent API structure.

### Changes Made
- **Client Implementation**: Updated `BolticClient` to expose `indexes` as a top-level getter alongside `tables`, `columns`, and `records`
- **Documentation**: Updated all SDK documentation to reflect the new `client.indexes.*` syntax
- **Examples**: Updated comprehensive demo and README examples to use the new API pattern
- **Backward Compatibility**: Maintained chained access pattern `client.from(table).indexes()` for table-scoped operations

### API Changes
**Before:**
```typescript
await client.tables.indexes.addIndex(tableName, request);
await client.tables.indexes.listIndexes(tableName, query);
await client.tables.indexes.deleteIndex(indexName);
```

**After:**
```typescript
await client.indexes.addIndex(tableName, request);
await client.indexes.listIndexes(tableName, query);
await client.indexes.deleteIndex(indexName);
```

### Breaking Changes
None - chained access pattern remains fully functional for backward compatibility.