### PR TITLE
BOLT_3570: Add db_id filter in table.findOne and table.findAll functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.0.10] - 2026-02-01
+
+> Fixed
+
+- Table list/findByName send db_id and resource_id in the request body filters; TableQueryOptions.where.resource_id for optional override (default 'boltic').
+- Use `options.where.resource_id` if provided; otherwise default to `'boltic'`.
+
 ## [v0.0.9] - 2026-01-14
 
 > Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@boltic/sdk",
-    "version": "0.0.9",
+    "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boltic/sdk",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "TypeScript SDK for Boltic databases infrastructure",
   "main": "dist/sdk.js",
   "module": "dist/sdk.mjs",

--- a/src/services/databases/package.json
+++ b/src/services/databases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boltic/sdk-databases",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Database service module for Boltic SDK",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/services/databases/src/types/api/table.ts
+++ b/src/services/databases/src/types/api/table.ts
@@ -97,6 +97,7 @@ export interface TableQueryOptions {
     id?: string;
     name?: string;
     db_id?: string;
+    resource_id?: string;
     is_public?: boolean;
     created_by?: string;
     created_at?: {


### PR DESCRIPTION
**Summary** 
Table list and findByName() were not scoping by the database correctly. After switching to a custom DB with useDatabase(), results could still come from the default database. This PR sends db_id and resource_id as filters in the request body so the backend scopes results correctly.

**Changes**
- `findAll()` & `findOne()` / `findByName()`: Add db_id and resource_id to the filters array in the POST body (no longer as query params or top-level body fields).
- Add db_id filter only when a database is set (e.g. after `useDatabase()`); when dbId is null/undefined, omit it so the backend uses the default database.
- Add resource_id filter: use `options.where.resource_id` when provided, otherwise default to 'boltic'.