### PR TITLE
BOLT-3870: Add source=sdk to SQL execute requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.3] - 2026-03-22
+
+> Added
+
+- Add `source=sdk` query parameter to SQL execution requests (`/tables/query/execute`) to identify executions originating from the SDK.
+
 ## [v0.1.2] - 2026-02-24
 
 > Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Added
 
-- Add `source=sdk` query parameter to SQL execution requests (`/tables/query/execute`) to identify executions originating from the SDK.
+- Add `x-request-source: sdk` header to SQL requests (`/tables/query/execute` and `/tables/query/text-to-sql`) to identify executions originating from SDK functions.
 
 ## [v0.1.2] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.1.3] - 2026-03-22
+## [v0.1.5] - 2026-03-27
 
 > Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@boltic/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boltic/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for Boltic databases infrastructure",
   "main": "dist/sdk.js",
   "module": "dist/sdk.mjs",

--- a/src/services/databases/examples/basic/comprehensive-sql-operations-demo.ts
+++ b/src/services/databases/examples/basic/comprehensive-sql-operations-demo.ts
@@ -39,6 +39,7 @@ const DEMO_CONFIG = {
   region: 'asia-south1' as const,
   maxRetries: 3,
   retryDelay: 1000,
+  environment: 'uat'
 };
 
 // Test table configuration

--- a/src/services/databases/examples/basic/comprehensive-sql-operations-demo.ts
+++ b/src/services/databases/examples/basic/comprehensive-sql-operations-demo.ts
@@ -39,7 +39,6 @@ const DEMO_CONFIG = {
   region: 'asia-south1' as const,
   maxRetries: 3,
   retryDelay: 1000,
-  environment: 'uat'
 };
 
 // Test table configuration

--- a/src/services/databases/src/api/clients/sql-api-client.ts
+++ b/src/services/databases/src/api/clients/sql-api-client.ts
@@ -73,11 +73,11 @@ export class SqlApiClient extends BaseApiClient {
   ): Promise<ExecuteSQLApiResponse | BolticErrorResponse> {
     try {
       const endpoint = SQL_ENDPOINTS.executeSQL;
-      let url = `${this.baseURL}${buildSqlEndpointPath(endpoint)}`;
-
+      const params = new URLSearchParams({ source: 'sdk' });
       if (dbId) {
-        url += `?db_id=${encodeURIComponent(dbId)}`;
+        params.set('db_id', dbId);
       }
+      const url = `${this.baseURL}${buildSqlEndpointPath(endpoint)}?${params.toString()}`;
 
       const response = await this.httpAdapter.request({
         url,

--- a/src/services/databases/src/api/clients/sql-api-client.ts
+++ b/src/services/databases/src/api/clients/sql-api-client.ts
@@ -41,7 +41,10 @@ export class SqlApiClient extends BaseApiClient {
       const response = await this.httpAdapter.request({
         url,
         method: endpoint.method,
-        headers: this.buildHeaders(),
+        headers: {
+          ...this.buildHeaders(),
+          'x-request-source': 'sdk',
+        },
         data: request,
         timeout: this.config.timeout,
       });
@@ -73,16 +76,19 @@ export class SqlApiClient extends BaseApiClient {
   ): Promise<ExecuteSQLApiResponse | BolticErrorResponse> {
     try {
       const endpoint = SQL_ENDPOINTS.executeSQL;
-      const params = new URLSearchParams({ source: 'sdk' });
+      let url = `${this.baseURL}${buildSqlEndpointPath(endpoint)}`;
+
       if (dbId) {
-        params.set('db_id', dbId);
+        url += `?db_id=${encodeURIComponent(dbId)}`;
       }
-      const url = `${this.baseURL}${buildSqlEndpointPath(endpoint)}?${params.toString()}`;
 
       const response = await this.httpAdapter.request({
         url,
         method: endpoint.method,
-        headers: this.buildHeaders(),
+        headers: {
+          ...this.buildHeaders(),
+          'x-request-source': 'sdk',
+        },
         data: request,
         timeout: this.config.timeout,
       });


### PR DESCRIPTION
This change replaces query-parameter source tagging with a request header for SQL API calls made by the SDK. The SDK now sends x-request-source: sdk for both /tables/query/execute and /tables/query/text-to-sql, enabling backend-side identification of SQL requests originating from SDK functions/servers.

**Testing:**
- Verified client request construction includes x-request-source: sdk for both API methods.