### PR TITLE
Cross-database table resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.7] - 2026-06-10
+
+> Fixed
+
+- **Cross-database table resolution** — when two databases under the same account had tables with the same name, record and column operations could silently target the wrong database's table:
+  - `records.insert` filled missing fields using columns resolved by table name without database context; the payload could carry a column from a same-named table in another database, causing API errors like `Extra field <name> provided`. Column completion now uses the already-resolved table id scoped with `db_id`.
+  - All `columns` operations (`create`, `createMany`, `findAll`, `findOne`, `findById`, `update`, `delete`) now scope table name resolution to the database selected via `useDatabase()`.
+
 ## [v0.1.5] - 2026-04-02
 
 > Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boltic/sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boltic/sdk",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boltic/sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TypeScript SDK for Boltic databases infrastructure",
   "main": "dist/sdk.js",
   "module": "dist/sdk.mjs",

--- a/src/services/databases/src/client/boltic-client.ts
+++ b/src/services/databases/src/client/boltic-client.ts
@@ -243,24 +243,25 @@ export class BolticClient {
 
   // Direct column operations
   get columns() {
+    const dbId = this.currentDatabase?.databaseId;
     return {
       create: (tableName: string, column: FieldDefinition) =>
-        this.columnResource.create(tableName, column),
+        this.columnResource.create(tableName, column, dbId),
       createMany: (tableName: string, columns: FieldDefinition[]) =>
-        this.columnResource.createMany(tableName, columns),
+        this.columnResource.createMany(tableName, columns, dbId),
       findAll: (tableName: string, options?: ColumnQueryOptions) =>
-        this.columnResource.findAll(tableName, options),
+        this.columnResource.findAll(tableName, options, dbId),
       findOne: (tableName: string, columnName: string) =>
-        this.columnResource.get(tableName, columnName),
+        this.columnResource.get(tableName, columnName, dbId),
       findById: (tableName: string, columnId: string) =>
-        this.columnResource.findById(tableName, columnId),
+        this.columnResource.findById(tableName, columnId, dbId),
       update: (
         tableName: string,
         columnName: string,
         updates: ColumnUpdateRequest
-      ) => this.columnResource.update(tableName, columnName, updates),
+      ) => this.columnResource.update(tableName, columnName, updates, dbId),
       delete: (tableName: string, columnName: string) =>
-        this.columnResource.delete(tableName, columnName),
+        this.columnResource.delete(tableName, columnName, dbId),
     };
   }
 

--- a/src/services/databases/src/client/resources/column.ts
+++ b/src/services/databases/src/client/resources/column.ts
@@ -52,11 +52,12 @@ export class ColumnResource extends BaseResource {
    */
   async create(
     tableName: string,
-    column: FieldDefinition
+    column: FieldDefinition,
+    dbId?: string
   ): Promise<BolticSuccessResponse<ColumnRecord> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -233,11 +234,12 @@ export class ColumnResource extends BaseResource {
    */
   async createMany(
     tableName: string,
-    columns: FieldDefinition[]
+    columns: FieldDefinition[],
+    dbId?: string
   ): Promise<BolticListResponse<ColumnRecord> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -282,11 +284,12 @@ export class ColumnResource extends BaseResource {
    */
   async findAll(
     tableName: string,
-    options: ColumnQueryOptions = {}
+    options: ColumnQueryOptions = {},
+    dbId?: string
   ): Promise<BolticListResponse<ColumnDetails> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -325,11 +328,12 @@ export class ColumnResource extends BaseResource {
    */
   async get(
     tableName: string,
-    columnName: string
+    columnName: string,
+    dbId?: string
   ): Promise<BolticSuccessResponse<ColumnDetails> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -374,11 +378,12 @@ export class ColumnResource extends BaseResource {
 
   async findById(
     tableName: string,
-    columnId: string
+    columnId: string,
+    dbId?: string
   ): Promise<BolticSuccessResponse<ColumnDetails> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -416,11 +421,12 @@ export class ColumnResource extends BaseResource {
   async update(
     tableName: string,
     columnName: string,
-    updates: ColumnUpdateRequest
+    updates: ColumnUpdateRequest,
+    dbId?: string
   ): Promise<BolticSuccessResponse<ColumnDetails> | BolticErrorResponse> {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -457,14 +463,15 @@ export class ColumnResource extends BaseResource {
    */
   async delete(
     tableName: string,
-    columnName: string
+    columnName: string,
+    dbId?: string
   ): Promise<
     | BolticSuccessResponse<{ success: boolean; message?: string }>
     | BolticErrorResponse
   > {
     try {
       // Get table information first
-      const tableInfo = await this.getTableInfo(tableName);
+      const tableInfo = await this.getTableInfo(tableName, dbId);
       if (!tableInfo) {
         return {
           error: {
@@ -504,12 +511,15 @@ export class ColumnResource extends BaseResource {
    * Helper method to get table information by name
    */
   private async getTableInfo(
-    tableName: string
+    tableName: string,
+    dbId?: string
   ): Promise<{ id: string; snapshot_url?: string } | null> {
     try {
-      // Use the table resource to find the table by name
+      // Use the table resource to find the table by name, scoped to the
+      // database context — a name-only lookup can resolve a same-named
+      // table in a different database
       const tableResource = new TableResource(this.client);
-      const tableResult = await tableResource.findByName(tableName);
+      const tableResult = await tableResource.findByName(tableName, dbId);
 
       if (tableResult.data) {
         return {

--- a/src/services/databases/src/client/resources/record.ts
+++ b/src/services/databases/src/client/resources/record.ts
@@ -17,7 +17,7 @@ import {
   isErrorResponse,
   BaseClient,
 } from '../../../../common';
-import { ColumnResource } from './column';
+import { ColumnsApiClient } from '../../api/clients/columns-api-client';
 import { TableResource } from './table';
 
 export class RecordResource {
@@ -66,8 +66,9 @@ export class RecordResource {
 
       // Get table columns to determine which fields might be missing
       const completeDataResult = await this.ensureCompleteRecordData(
-        tableName,
-        data
+        tableInfo.id,
+        data,
+        dbId
       );
       if ('error' in completeDataResult && completeDataResult.error) {
         return completeDataResult as BolticErrorResponse;
@@ -461,12 +462,26 @@ export class RecordResource {
    * filling missing ones with null.
    */
   private async ensureCompleteRecordData(
-    tableName: string,
-    data: RecordData
+    tableId: string,
+    data: RecordData,
+    dbId?: string
   ): Promise<RecordData | BolticErrorResponse> {
     try {
-      const columnResource = new ColumnResource(this.client);
-      const columnsResult = await columnResource.findAll(tableName);
+      // Fetch columns by the already-resolved table id (scoped to dbId) —
+      // resolving by table name here could hit a same-named table in
+      // another database and poison the payload with its columns
+      const columnsApiClient = new ColumnsApiClient(
+        this.client.getConfig().apiKey,
+        {
+          environment: this.client.getConfig().environment,
+          region: this.client.getConfig().region,
+          timeout: this.client.getConfig().timeout,
+          debug: this.client.getConfig().debug,
+        }
+      );
+      const columnsResult = await columnsApiClient.listColumns(tableId, {
+        db_id: dbId,
+      });
 
       if (isErrorResponse(columnsResult)) {
         return columnsResult;


### PR DESCRIPTION
Cross-database table resolution— when two databases under the same account had tables with the same name, record and column operations could silently target the wrong database's table